### PR TITLE
Fix inline rendering failure

### DIFF
--- a/suit_redactor/widgets.py
+++ b/suit_redactor/widgets.py
@@ -49,7 +49,6 @@ document.addEventListener("DOMContentLoaded", function() {
                     var id = subChild.id.match(%s);
                     if(id !== null && id[0] !== undefined){
                         $('#' + id[0]).redactor(%s);
-                        console.debug('Activate redactor for '+id[0]);
                     };
                 }
             });

--- a/suit_redactor/widgets.py
+++ b/suit_redactor/widgets.py
@@ -25,7 +25,41 @@ class RedactorWidget(Textarea):
 
     def render(self, name, value, attrs=None):
         output = super(RedactorWidget, self).render(name, value, attrs)
-        output += mark_safe(
-            '<script type="text/javascript">$("#id_%s").redactor(%s);</script>'
-            % (name, json.dumps(self.editor_options)))
+        blank_element = '-__prefix__-'
+        editor_options = json.dumps(self.editor_options)
+        if blank_element in name:
+            try:
+                prefix, suffix = name.split(blank_element)
+            except KeyError:
+                return output
+            dom_id = r'/id_{}-\d+-{}/g'.format(prefix, suffix)
+            output += mark_safe("""
+<script type="text/javascript">
+document.addEventListener("DOMContentLoaded", function() {
+    Suit.after_inline.register('%s', function (prefix, row) {
+        if(row === undefined || row[0] === undefined || !row[0].childNodes){
+            return;
+        }
+        row[0].childNodes.forEach(function(child) {
+            if(!child.childNodes){
+                return;
+            }
+            child.childNodes.forEach(function(subChild) {
+                if(subChild.id){
+                    var id = subChild.id.match(%s);
+                    if(id !== null && id[0] !== undefined){
+                        $('#' + id[0]).redactor(%s);
+                        console.debug('Activate redactor for '+id[0]);
+                    };
+                }
+            });
+        });
+    });
+});
+</script>
+            """ % (prefix, dom_id, editor_options))
+        else:
+            output += mark_safe(
+                '<script type="text/javascript">$("#id_%s").redactor(%s);</script>'
+                % (name, editor_options))
         return output


### PR DESCRIPTION
This pull request fix this issue:
https://github.com/darklow/django-suit-redactor/issues/13
The new row with `__prefix__` is processed to render the element correctly. 