### PR TITLE
Adding missing renderer argument for Django 2.1+ compatibility - Update widgets.py

### DIFF
--- a/suit_redactor/widgets.py
+++ b/suit_redactor/widgets.py
@@ -23,7 +23,7 @@ class RedactorWidget(Textarea):
         super(RedactorWidget, self).__init__(attrs)
         self.editor_options = editor_options
 
-    def render(self, name, value, attrs=None):
+    def render(self, name, value, attrs=None, renderer=None):
         output = super(RedactorWidget, self).render(name, value, attrs)
         output += mark_safe(
             '<script type="text/javascript">$("#id_%s").redactor(%s);</script>'


### PR DESCRIPTION
Support for Widget.render() methods without the renderer argument is removed in Django 2.1+
Therefor "renderer=None" has been added.