### PR TITLE
Django 3 compatibility

### DIFF
--- a/suit_redactor/widgets.py
+++ b/suit_redactor/widgets.py
@@ -1,7 +1,7 @@
 # from django.core.serializers import json
 from django.forms import Textarea
 from django.utils.safestring import mark_safe
-from django.contrib.staticfiles.templatetags.staticfiles import static
+from django.templatetags.static import static
 
 try:
     import json
@@ -23,8 +23,8 @@ class RedactorWidget(Textarea):
         super(RedactorWidget, self).__init__(attrs)
         self.editor_options = editor_options
 
-    def render(self, name, value, attrs=None):
-        output = super(RedactorWidget, self).render(name, value, attrs)
+    def render(self, name, value, attrs=None, renderer=None):
+        output = super(RedactorWidget, self).render(name, value, attrs, renderer=renderer)
         output += mark_safe(
             '<script type="text/javascript">$("#id_%s").redactor(%s);</script>'
             % (name, json.dumps(self.editor_options)))


### PR DESCRIPTION
I know this repo is effectively abandoned, but opening this PR just in case anyone else is using `django-suit-redactor` and trying to upgrade to a recent version of Django.

I pulled in @dennisvd's changes from #18 and fixed the imports. 

Unsure if anything else would be needed to fully support Django 3.2+, but this worked for me. YMMV

The Django 3 compatible `django-suit` + `django-suit-redactor` versions I'm pulling in from `requirements.txt`:

```  
git+https://github.com/coredumperror/django-suit.git@master
git+https://github.com/erik/django-suit-redactor.git@patch-1
```